### PR TITLE
Translation services tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,7 @@ test_script:
   - Build test
   - perl -MDevel::Cover t/compile.t
   - perl -MDevel::Cover t/engine.t
+  - perl -MDevel::Cover t/plugins.t
 
 after_test:
   - cover -report codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script:
   - cover -delete
   - perl -MDevel::Cover t/compile.t
   - perl -MDevel::Cover t/engine.t
+  - perl -MDevel::Cover t/plugins.t
 after_success:
   - cover -report codecov
 perl:

--- a/t/data/plugins/pootle/00/commands/pull.json
+++ b/t/data/plugins/pootle/00/commands/pull.json
@@ -1,0 +1,5 @@
+[
+   {
+      "command" : "./pootle/manage.py sync_stores --skip-missing --project=SergeTest"
+   }
+]

--- a/t/data/plugins/pootle/00/commands/push.json
+++ b/t/data/plugins/pootle/00/commands/push.json
@@ -1,0 +1,5 @@
+[
+   {
+      "command" : "./pootle/manage.py update_stores --project=SergeTest"
+   }
+]

--- a/t/data/plugins/pootle/00/files/config/serge_test.yml
+++ b/t/data/plugins/pootle/00/files/config/serge_test.yml
@@ -1,0 +1,20 @@
+
+"project_identifier" : "serge_test"
+"api_key" : "1234567890abcdefghklmnoprstuvxwy"
+"base_path" : "./files/resources"
+
+"preserve_hierarchy": false
+
+files: [
+{
+  "source" : "en/*.po",
+
+  "translation" : "/%two_letters_code%/%original_file_name%",
+
+  "languages_mapping" : {
+    "two_letters_code" : {
+      "crowdin_language_code" : "local_name"
+    }
+  },
+}
+]

--- a/t/data/plugins/pootle/00/files/resources/.gitignore
+++ b/t/data/plugins/pootle/00/files/resources/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/t/data/plugins/pootle/00/pootle/manage.py
+++ b/t/data/plugins/pootle/00/pootle/manage.py
@@ -1,0 +1,1 @@
+print("pootle")

--- a/t/data/plugins/pootle/00/translate.serge
+++ b/t/data/plugins/pootle/00/translate.serge
@@ -1,0 +1,14 @@
+sync
+{
+    ts
+    {
+        plugin                      pootle
+
+        data
+        {
+            project_id              SergeTest
+
+            manage_py_path          ./pootle/manage.py
+        }
+    }
+}

--- a/t/data/plugins/pootle/01/reference-errors/new.txt
+++ b/t/data/plugins/pootle/01/reference-errors/new.txt
@@ -1,0 +1,1 @@
+Data validation failed for plugin 'Serge::Sync::Plugin::TranslationService::pootle': 'manage_py_path', which is set to './pootle/not-found.py', does not point to a valid file.

--- a/t/data/plugins/pootle/01/translate.serge
+++ b/t/data/plugins/pootle/01/translate.serge
@@ -1,0 +1,14 @@
+sync
+{
+    ts
+    {
+        plugin                      pootle
+
+        data
+        {
+            project_id              SergeTest
+
+            manage_py_path          ./pootle/not-found.py
+        }
+    }
+}

--- a/t/data/plugins/pootle/02/commands/pull.json
+++ b/t/data/plugins/pootle/02/commands/pull.json
@@ -1,0 +1,5 @@
+[
+   {
+      "command" : "./pootle/manage.py sync_stores --skip-missing --project=SergeTest --language=es --language=fr_CA"
+   }
+]

--- a/t/data/plugins/pootle/02/commands/push.json
+++ b/t/data/plugins/pootle/02/commands/push.json
@@ -1,0 +1,5 @@
+[
+   {
+      "command" : "./pootle/manage.py update_stores --project=SergeTest --language=es --language=fr_CA"
+   }
+]

--- a/t/data/plugins/pootle/02/files/config/serge_test.yml
+++ b/t/data/plugins/pootle/02/files/config/serge_test.yml
@@ -1,0 +1,20 @@
+
+"project_identifier" : "serge_test"
+"api_key" : "1234567890abcdefghklmnoprstuvxwy"
+"base_path" : "./files/resources"
+
+"preserve_hierarchy": false
+
+files: [
+{
+  "source" : "en/*.po",
+
+  "translation" : "/%two_letters_code%/%original_file_name%",
+
+  "languages_mapping" : {
+    "two_letters_code" : {
+      "crowdin_language_code" : "local_name"
+    }
+  },
+}
+]

--- a/t/data/plugins/pootle/02/files/resources/.gitignore
+++ b/t/data/plugins/pootle/02/files/resources/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/t/data/plugins/pootle/02/pootle/manage.py
+++ b/t/data/plugins/pootle/02/pootle/manage.py
@@ -1,0 +1,1 @@
+print("pootle")

--- a/t/data/plugins/pootle/02/translate.serge
+++ b/t/data/plugins/pootle/02/translate.serge
@@ -1,0 +1,16 @@
+sync
+{
+    ts
+    {
+        plugin                      pootle
+
+        data
+        {
+            project_id              SergeTest
+
+            manage_py_path          ./pootle/manage.py
+        }
+    }
+
+    langs                           es fr-ca
+}

--- a/t/lib/Test/PluginHost.pm
+++ b/t/lib/Test/PluginHost.pm
@@ -1,0 +1,18 @@
+package Test::PluginHost;
+use parent Serge::Interface::PluginHost;
+
+use strict;
+
+sub new {
+    my ($class) = @_;
+
+    my $self = {
+        debug               => 1
+    };
+
+    bless $self, $class;
+
+    return $self;
+}
+
+1;

--- a/t/lib/Test/PluginsConfig.pm
+++ b/t/lib/Test/PluginsConfig.pm
@@ -1,0 +1,58 @@
+package Test::PluginsConfig;
+
+use parent Serge::Config;
+
+use strict;
+
+use File::Basename;
+use File::Spec::Functions qw/catfile rel2abs/;
+
+our $REFERENCE_ERRORS_DIR = './reference-errors';
+our $ERRORS_DIR = './errors';
+
+#
+# Initialize object
+#
+sub new {
+    my ($class, $path) = @_;
+
+    die "path not provided" unless $path;
+    $path = rel2abs($path);
+
+    # Load config file
+    my $data;
+
+    my $s = Config::Neat::Schema->new();
+    $s->load(dirname(__FILE__).'/plugins_config_schema.serge');
+
+    my $c = Config::Neat::Inheritable->new();
+    $data = $c->parse_file($path);
+
+    die "Config is not a hash\n" unless ref($data) eq 'HASH';
+
+    $s->validate($data);
+
+    # Check config validity
+
+    my $self = {
+        base_dir => dirname($path),
+        data => $data,
+    };
+    bless $self, $class;
+
+    return $self;
+}
+
+sub errors_path {
+    my $self = shift;
+
+    return catfile($self->{base_dir}, $ERRORS_DIR);
+}
+
+sub reference_errors_path {
+    my $self = shift;
+
+    return catfile($self->{base_dir}, $REFERENCE_ERRORS_DIR);
+}
+
+1;

--- a/t/lib/Test/SysCmdRunner.pm
+++ b/t/lib/Test/SysCmdRunner.pm
@@ -1,0 +1,181 @@
+package Test::SysCmdRunner;
+use parent Serge::Interface::PluginHost;
+
+use strict;
+use warnings;
+
+use JSON -support_by_pp; # -support_by_pp is used to make Perl on Mac happy
+use Encode qw(decode encode_utf8 decode_utf8);
+use File::Path;
+use File::Spec::Functions qw(catfile);
+use Cwd;
+
+our $UNIX_PATH_SEPARATOR = '/';
+our $WINDOWS_PATH_SEPARATOR = '\\';
+
+sub new {
+    my ($class, $ts_command) = @_;
+
+    my $self = {
+        ts_command    => $ts_command,
+        echo_output   => 1,
+        echo_commands => 1,
+        debug         => 1,
+        init          => 0
+    };
+
+    bless $self, $class;
+
+    return $self;
+}
+
+sub start {
+    my ($self) = @_;
+
+    if ($self->{init}) {
+        $self->{commands} = [];
+
+        return;
+    }
+
+    my $commands_path = './commands/';
+
+    my $filename = catfile($commands_path, $self->{ts_command}.'.json');
+
+    if (!open(TS, $filename)) {
+        print "WARNING: Can't read $filename: $!\n";
+        return;
+    }
+    binmode(TS);
+    my $text = decode_utf8(join('', <TS>));
+    close(TS);
+
+    $self->{commands} = $self->parse_json($text);
+}
+
+sub run_cmd {
+    my ($self, $command, $capture, $ignore_codes) = @_;
+
+    my $expected_command;
+
+    if (not $self->{init}) {
+        # need for Windows, where path separator is '\'
+        my $path_separator = catfile('', '');
+
+        if ($path_separator eq $WINDOWS_PATH_SEPARATOR) {
+            # Switching Windows path separator to Unix path separator.
+            $command =~ s{\\}{/}g;
+        }
+
+        my $commands_ref = $self->{commands};
+
+        die "$command not found" unless ref($commands_ref) eq 'ARRAY';
+
+        my @commands = @$commands_ref;
+
+        $expected_command = shift @commands;
+
+        $self->{commands} = \@commands;
+
+        die "$command not found" unless $expected_command;
+        die "$command not found" unless $expected_command->{command};
+        die "$command not found as expected (found $expected_command->{command})" if $expected_command->{command} ne $command;
+    } else {
+        $expected_command = {
+            command  => $command
+        };
+
+        my $commands_ref = $self->{commands};
+
+        my @commands = @$commands_ref;
+
+        push @commands, $expected_command;
+
+        $self->{commands} = \@commands;
+    }
+
+    my $result;
+    if ($capture) {
+        $result = '';
+    } else {
+        $result = 0;
+    }
+
+    if (not $self->{init}) {
+        if ($capture) {
+            $result = $expected_command->{output} if defined $expected_command->{output};
+
+            print "\n--------------------\n$result\n--------------------\n" if $self->{echo_output};
+        } else {
+            $result = $expected_command->{result} if defined $expected_command->{result};
+        }
+    }
+
+    my $error_code = 0;
+
+    if (not $self->{init}) {
+        $error_code = $expected_command->{error_code} if $expected_command->{error_code};
+
+        if (($error_code > 0) && $ignore_codes && (ref(\$ignore_codes) eq 'SCALAR' || (grep ($_ eq $error_code, @$ignore_codes) > 0))) {
+            print "Exit code: $error_code (ignored)\n" if $self->{debug};
+            $error_code = 0;
+        }
+
+        die $result . "\nExit code: $error_code; last error: $!\n" if $error_code != 0;
+    }
+
+    return $result;
+}
+
+sub stop {
+    my ($self) = @_;
+
+    if (not $self->{init}) {
+        return;
+    }
+
+    my $commands_ref = $self->{commands};
+
+    if (ref($commands_ref) eq 'ARRAY') {
+        my $commands_path = './commands/';
+
+        eval { mkpath($commands_path) };
+        die "Couldn't create $commands_path: $@" if $@;
+
+        my $filename = catfile($commands_path, $self->{ts_command}.'.json');
+
+        my $json = JSON->new;
+
+        my $commands_json = $json->pretty->encode($commands_ref);
+
+        open my $OUT, ">", $filename or die "Failed to open file [$filename] for writing: $!";
+        binmode $OUT;
+        print $OUT $commands_json;
+
+        close $OUT;
+    }
+}
+
+sub parse_json {
+    my ($self, $json) = @_;
+
+    my $tree;
+    eval {
+        ($tree) = from_json($json, {relaxed => 1});
+    };
+    if ($@ || !$tree) {
+        my $error_text = $@;
+        if ($error_text) {
+            $error_text =~ s/\t/ /g;
+            $error_text =~ s/^\s+//s;
+        } else {
+            $error_text = "from_json() returned empty data structure";
+        }
+
+        die $error_text;
+    }
+
+    return $tree;
+}
+
+1;

--- a/t/lib/Test/plugins_config_schema.serge
+++ b/t/lib/Test/plugins_config_schema.serge
@@ -1,0 +1,14 @@
+sync
+{
+    ts
+    {
+        plugin                      STRING
+        data
+        {
+            *                       DATA
+        }
+    }
+
+    langs                           ARRAY
+}
+

--- a/t/plugins.t
+++ b/t/plugins.t
@@ -1,0 +1,197 @@
+use strict;
+
+# HOW TO USE THIS TEST
+#
+# By default, this test runs over all directories in t/data/plugins/.  To run
+# the test only for specific directories, pass the directory names to this
+# script or assign them to the environment variable SERGE_PLUGINS_TESTS as a
+# comma-separated list.  The following two examples are equivalent:
+#
+# perl t/plugins.t mojito zanata
+# SERGE_PLUGINS_TESTS=mojito,zanata prove t/engine.t
+
+BEGIN {
+    use Cwd qw(abs_path);
+    use File::Basename;
+    use File::Spec::Functions qw(catfile);
+    map { unshift(@INC, catfile(dirname(abs_path(__FILE__)), $_)) } qw(lib ../lib);
+}
+
+use File::Copy::Recursive qw/dircopy/;
+use File::Find qw(find);
+use File::Path;
+use File::Spec::Functions qw(catfile);
+use Getopt::Long;
+use Test::More;
+use Serge::Interface::SysCmdRunner;
+use Serge::Config;
+use Test::PluginHost;
+use Test::SysCmdRunner;
+use Test::Diff;
+use Test::PluginsConfig;
+
+$| = 1; # disable output buffering
+
+my $sys_cmd_runner;
+my $init_commands;
+
+# as the real command line interfaces cannot be invoked,
+# we override the `run_cmd` function;
+sub Serge::Interface::SysCmdRunner::run_cmd {
+    my ($self, $command, $capture, $ignore_codes) = @_;
+
+    die 'Undefined system command runner' unless $sys_cmd_runner;
+
+    return $sys_cmd_runner->run_cmd($command, $capture, $ignore_codes);
+}
+
+sub output_errors {
+    my ($error, $errors_path, $filename, $plugin) = @_;
+
+    # cleanup error message to avoid having file paths that will differ across installations
+    $error =~ s/\s+$//sg;
+    $error =~ s/ at .*? line \d+\.$//s;
+    $error =~ s/ \(\@INC contains: .*\)$//s;
+    $error =~ s/\@INC.+$/\@INC/s;
+
+    print "Plugin '$plugin' will be skipped: $error\n";
+
+    eval { mkpath($errors_path) };
+    die "Couldn't create $errors_path: $@" if $@;
+    my $full_filename = catfile('./errors/', $filename);
+    open(OUT, ">$full_filename");
+    binmode(OUT, ':utf8');
+    print OUT $error;
+    close(OUT);
+}
+
+sub delete_directory {
+    my ($path, $ignore_errors) = @_;
+
+    my $err;
+
+    if (-e $path) {
+        rmtree($path, { error => \$err });
+        if (@$err && !$ignore_errors) {
+            my $err_text = '';
+
+            map {
+                foreach my $key (keys %$_) {
+                    $err_text .= $key.': '.$_->{$key}."\n";
+                }
+            } @$err;
+
+            BAIL_OUT("Directory '".$path."' couldn't be removed\n$err_text");
+        }
+    }
+}
+
+sub test_ts {
+    my ($ts, $plugin, $cfg, $name, $command, $langs) = @_;
+
+    my $ok = 1;
+
+    $sys_cmd_runner = Test::SysCmdRunner->new($name);
+
+    $sys_cmd_runner->{init} = $init_commands;
+
+    $sys_cmd_runner->start();
+
+    my $command_result = 1;
+
+    eval {
+        if ($langs) {
+            $command_result = $ts->$command($langs);
+        }
+        else {
+            $command_result = $ts->$command();
+        }
+    };
+
+    output_errors($@, $cfg->errors_path, "$name.txt", $plugin) if $@;
+
+    $sys_cmd_runner->stop();
+
+    if (not $@) {
+        $ok &= ok($command_result eq 0, "'$name'") unless $init_commands;
+    }
+
+    return $ok;
+}
+
+my $this_dir = dirname(abs_path(__FILE__));
+my $tests_dir = catfile($this_dir, 'data', 'plugins');
+
+my @confs;
+
+GetOptions("init" => \$init_commands);
+
+my @dirs = @ARGV;
+if (my $env_dirs = $ENV{SERGE_PLUGINS_TESTS}) {
+    push @dirs, split(/,/, $env_dirs);
+}
+
+unless (@dirs) {
+    find(sub {
+        push @confs, $File::Find::name if(-f $_ && /\.serge$/ && $_ ne 'common.serge');
+    }, $tests_dir);
+} else {
+    for my $dir (@dirs) {
+        find(sub {
+            push @confs, $File::Find::name if(-f $_ && /\.serge$/ && $_ ne 'common.serge');
+        }, catfile($tests_dir, $dir));
+    }
+}
+
+my $plugin_host = Test::PluginHost->new();
+
+for my $config_file (@confs) {
+
+    subtest "Test config: $config_file" => sub {
+        my $cfg = Test::PluginsConfig->new($config_file);
+
+        SKIP: {
+            my $ok = ok(defined $cfg, 'Config file read');
+
+            $cfg->chdir;
+
+            delete_directory($cfg->errors_path);
+            if ($init_commands) {
+                delete_directory($cfg->reference_errors_path);
+            }
+
+            my $ts;
+            my $plugin = '';
+
+            eval {
+                $plugin = $cfg->{data}->{sync}->{ts}->{plugin};
+
+                $ts = $plugin_host->load_plugin_from_node(
+                    'Serge::Sync::Plugin::TranslationService',
+                    $cfg->{data}->{sync}->{ts}
+                );
+            };
+
+            output_errors($@, $cfg->errors_path, 'new.txt', $plugin) if $@;
+
+            if (not $@ and $ts) {
+                my $langs = $cfg->{data}->{sync}->{langs};
+
+                $ok &= test_ts($ts, $plugin, $cfg, 'pull', 'pull_ts', $langs);
+
+                $ok &= test_ts($ts, $plugin, $cfg, 'push', 'push_ts', $langs);
+            }
+
+            if ($init_commands) {
+                ok(dircopy($cfg->errors_path, $cfg->reference_errors_path), "Initialized ".$cfg->reference_errors_path) if -e $cfg->errors_path;
+            }
+            else {
+                $ok &= dir_diff($cfg->errors_path, $cfg->reference_errors_path, { base_dir => $cfg->{base_dir} }) if -e $cfg->reference_errors_path;
+            }
+
+            delete_directory($cfg->errors_path) if $ok;
+        }
+    }
+}
+
+done_testing();


### PR DESCRIPTION
Allows testing for pootle and any other future supported translation services. Using similar declarative approach like the engine tests. Also increases real code coverage.